### PR TITLE
Use `orderedItems` field for OrderedCollection

### DIFF
--- a/src/model-interfaces/collections/ordered-collection.interface.ts
+++ b/src/model-interfaces/collections/ordered-collection.interface.ts
@@ -41,10 +41,10 @@ export interface APOrderedCollection extends APObject {
     last?: OrderedCollectionLastField;
 
     /**
-     * Identifies the items contained in a collection.
-     * The items might be ordered or unordered.
+     * Identifies the ordered items contained in a collection.
+     * The items must be ordered.
      *
-     * {@link https://www.w3.org/ns/activitystreams#items Docs}
+     * {@link https://www.w3.org/ns/activitystreams#orderedItems Docs}
      */
-    items?: OrderedCollectionItemsField[];
+    orderedItems?: OrderedCollectionItemsField[];
 }


### PR DESCRIPTION
As per [the spec](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-orderedcollection) ordered collections use an `orderedItems` field.

This is causing me some issues for stuff like the followers list in my ap implementation.